### PR TITLE
fixes #7 and prepares #8

### DIFF
--- a/Piwo.class.php
+++ b/Piwo.class.php
@@ -12,6 +12,30 @@ class Piwo {
 		$parser->setFunctionHook( 'piwo', 'Piwo::execPy', Parser::SFH_OBJECT_ARGS );
 	}
 
+	/**
+   * execute python code
+   */
+	public static function execPython($name,$cmdargs) {
+		putenv('MW_PIWO='.__DIR__);
+		putenv('MW_ROOT='.dirname(dirname(__DIR__)));
+    putenv('MW_GRAM_NAME='.$name);
+    $shellcmd="";
+    $first=True;
+    foreach ($cmdargs as $arg) {
+			if ($first) {
+				$shellcmd=$arg;
+  			$first=False;
+			} else {
+				$shellcmd.=' '.escapeshellarg($arg);
+			}
+    }
+    $shellcmd.=" 2>&1";
+    #$output=$shellcmd;
+    $output=shell_exec($shellcmd);
+    return $output;
+  }
+
+
   /**
    * execute python code
    */
@@ -65,7 +89,7 @@ EOS;
 import sys
 sys.path.append('$wd')
 $content
-EOS; 
+EOS;
 		}
 	
 		file_put_contents($filename, $content);
@@ -73,7 +97,9 @@ EOS;
 		foreach ($params as $i => $par) {
 			if ($i > 0) $cmdargs[] = $frame->expand( $par );
 		}
-		$output = self::execJailedPython($name,$cmdargs);
+		# we need some condition here to decide ...
+		$output = self::execPython($name,$cmdargs);
+		#$output = self::execJailedPython($name,$cmdargs);
 
 		return [ $output, 'noparse' => false ];
 	}

--- a/Piwo.class.php
+++ b/Piwo.class.php
@@ -1,5 +1,5 @@
 <?php
-define( 'CONTENT_MODEL_PIWO', 'Piwo' );
+define('CONTENT_MODEL_PIWO', 'Piwo');
 
 use MediaWiki\Shell\Shell;
 use MediaWiki\MediaWikiServices;
@@ -11,6 +11,34 @@ class Piwo {
 		//the "python" magic word with execPy()
 		$parser->setFunctionHook( 'piwo', 'Piwo::execPy', Parser::SFH_OBJECT_ARGS );
 	}
+
+  /**
+   * execute python code
+   */
+	public static function execJailedPython($name,$cmdargs) {
+		$result = Shell::command($cmdargs)
+			->environment( [
+				'MW_PIWO' => __DIR__,
+				'MW_ROOT' => dirname(dirname(__DIR__)),
+				'MW_GRAM_NAME' => $name
+			] )
+			->limits( [ 'time' => 300 ] )
+			->execute();
+		$exitCode = $result->getExitCode();
+		$stdout = $result->getStdout();
+		$stderr = $result->getStderr();
+		if ($exitCode == 0) {
+			$output = $stdout;
+		} else {
+			$output = <<<EOS
+<p class="error">[[Gram:$name]] exited with code $exitCode:</p>
+<pre>$stdout</pre>
+<pre class="error">$stderr</pre>
+EOS;
+		}
+		return $output;
+	}
+
 
 	// Render the output of {{#python:gram}}.
 	public static function execPy( $parser, $frame, $params ) {
@@ -30,35 +58,23 @@ EOS;
 import mw
 $content
 EOS;
-		$content = <<<EOS
+		# check magic content
+        if (strpos($content, "PIWO: do not touch")) {}
+		else {
+			$content = <<<EOS
 import sys
 sys.path.append('$wd')
 $content
-EOS;
+EOS; 
+		}
+	
 		file_put_contents($filename, $content);
 		$cmdargs = ["python3", $filename];
 		foreach ($params as $i => $par) {
 			if ($i > 0) $cmdargs[] = $frame->expand( $par );
 		}
-		$result = Shell::command($cmdargs)
-			->environment( [
-				'MW_ROOT' => dirname(dirname(__DIR__)),
-				'MW_GRAM_NAME' => $name
-			] )
-			->limits( [ 'time' => 300 ] )
-			->execute();
-		$exitCode = $result->getExitCode();
-		$stdout = $result->getStdout();
-		$stderr = $result->getStderr();
-		if ($exitCode == 0) {
-			$output = $stdout;
-		} else {
-			$output = <<<EOS
-<p class="error">[[Gram:$name]] exited with code $exitCode:</p>
-<pre>$stdout</pre>
-<pre class="error">$stderr</pre>
-EOS;
-		}
+		$output = self::execJailedPython($name,$cmdargs);
+
 		return [ $output, 'noparse' => false ];
 	}
 


### PR DESCRIPTION
With this state i can at least debug in the IDE since the code is left alone if it starts with:
```python
# PIWO do not touch
# import mw
```
The debug test code i am using is below. It uses the new env variable MW_PIWO to find out that PIWO is active. That way the code can run in the IDE in a different way.
```python
# PIWO: do not touch
# import mw
import os
import sys

print ("before debug is on: %s" % os.path.abspath(__file__))

piwo=None
# check we are called from the Piwo extension
if 'MW_PIWO' in os.environ:
    # add path to mw.py
    piwo=os.environ['MW_PIWO']
    sys.path.append(piwo)
    # import it
    import mw
    # activate debugging
    debugServer=None
    debugServer="pan.bitplan.com"
    if debugServer is not None:
        os.environ["PATHS_FROM_ECLIPSE_TO_PYTHON"]='[["/Users/wf/Documents/pyworkspace/piwodebug/", "/tmp/"]]'
        import pydevd
        pydevd.settrace(debugServer, port=5678,stdoutToServer=True, stderrToServer=True)
        print("trying to debug with PATHS_FROM_ECLIPSE_TO_PYTHON=%s" % os.environ["PATHS_FROM_ECLIPSE_TO_PYTHON"]);
     
print ("after debug is on: %s" % os.path.abspath(__file__))

a = 2
b = 3
c = a * b

s = 'hello world a=%d b=%d c=%d' % (a,b,c)

print(s)
```